### PR TITLE
Add Getting Started to Installation Sidebar Menu

### DIFF
--- a/_data/thirtybees/thirtybees_sidebar.yml
+++ b/_data/thirtybees/thirtybees_sidebar.yml
@@ -40,6 +40,14 @@ entries:
     version: all
     output: web, pdf
 
+  - title: Getting Started
+    url: /Installation/getting_started.md
+    audience: developers
+    platform: all
+    product: all
+    version: all
+    output: web, pdf
+
   - title: Troubleshooting
     audience: developers
     platform: all


### PR DESCRIPTION
Add the Link to Getting Started under Installation in Sidebar Menu.