### PR TITLE
pdf-catalog.html

### DIFF
--- a/_includes/custom/pdf-catalog.html
+++ b/_includes/custom/pdf-catalog.html
@@ -1,0 +1,18 @@
+<aside>
+<header class="panel panel-default>
+<div class="panel-heading>
+<h1 class="panel-title">
+thirty bees Merchant Guide [pdf]
+</h1>
+</header>
+</div>
+<div class="panel-body">
+<p>You can download this entire guide, a comprehensive PDF containing all the content on this site and all its sections, right here!  Work when, where and how you want!</p>
+
+<p><a rel="help bookmark" target="_blank" class="noCrossRef" href="{{base}}/thirtybees/pdf/thirtybees_devdocs.pdf"><button type="button" class="btn btn-default" class="pull-right" aria-label="Left Align"><span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> PDF Download</button></a></p>
+</div>
+<footer class="panel-footer">
+The PDF contains a timestamp in the header indicating when it was last generated.
+</footer>
+</aside>
+


### PR DESCRIPTION
pdf-catalog.html in `_custom/` folder is a code snippet to include in every page. It displays a method to download pdf documentation.